### PR TITLE
[gallery] - rwd images

### DIFF
--- a/templates/single-property/property-images.php
+++ b/templates/single-property/property-images.php
@@ -2,8 +2,8 @@
 /**
  * Single Property Images
  *
- * @author 		PropertyHive
- * @package 	PropertyHive/Templates
+ * @author      PropertyHive
+ * @package     PropertyHive/Templates
  * @version     1.0.0
  */
 
@@ -14,29 +14,30 @@ global $post, $propertyhive, $property;
 $gallery_attachments = $property->get_gallery_attachment_ids();
 ?>
 <div class="images">
-    
-	<?php
-		if ( !empty($gallery_attachments) ) {
-            
+
+    <?php
+        if ( !empty($gallery_attachments) ) {
+
             echo '<div id="slider" class="flexslider"><ul class="slides">';
-            
+
             foreach ($gallery_attachments as $gallery_attachment)
             {
-    			 $image_title = esc_attr( get_the_title( $gallery_attachment ) );
-    			 $image_link  = wp_get_attachment_url( $gallery_attachment );
-         
-			     echo '<li>' . apply_filters( 'propertyhive_single_property_image_html', sprintf( '<a href="%s" class="propertyhive-main-image" title="%s" data-rel="prettyPhoto[ph_photos]"><img src="%s" alt="%s"></a>', $image_link, $image_title, $image_link, $image_title ), $post->ID ) . '</li>';
+                $image_title = esc_attr( get_the_title( $gallery_attachment ) );
+                $image_link  = wp_get_attachment_url( $gallery_attachment );
+                $image = wp_get_attachment_image( $gallery_attachment, 'original' );
+
+                echo '<li>' . apply_filters( 'propertyhive_single_property_image_html', sprintf( '<a href="%s" class="propertyhive-main-image" title="%s" data-rel="prettyPhoto[ph_photos]">%s</a>', $image_link, $image_title, $image ), $post->ID ) . '</li>';
             }
-            
+
             echo '</ul></div>';
-            
-		} else {
 
-			echo apply_filters( 'propertyhive_single_property_image_html', sprintf( '<img src="%s" alt="Placeholder" />', ph_placeholder_img_src() ), $post->ID );
+        } else {
 
-		}
-	?>
+            echo apply_filters( 'propertyhive_single_property_image_html', sprintf( '<img src="%s" alt="Placeholder" />', ph_placeholder_img_src() ), $post->ID );
 
-	<?php do_action( 'propertyhive_product_thumbnails' ); ?>
+        }
+    ?>
+
+    <?php do_action( 'propertyhive_product_thumbnails' ); ?>
 
 </div>


### PR DESCRIPTION
Hi Steve,

Gallery is outputting full original images at the moment, so changed it up to use WordPress's core RWD images.

Be good to change the `original` image source to `property_single` at some point like WooCommerce has, but as there isn't that image defined I've left as `original` but now smaller screen widths do not serve up `original` image size.

Thanks,
Tom