### PR TITLE
[function] - fix propertyhive_get_property_thumbnail() to accept argu…

### DIFF
--- a/includes/ph-template-functions.php
+++ b/includes/ph-template-functions.php
@@ -28,7 +28,7 @@ function ph_setup_property_data( $post ) {
         return;
 
     $GLOBALS['property'] = get_property( $post );
-    
+
     return $GLOBALS['property'];
 }
 add_action( 'the_post', 'ph_setup_property_data' );
@@ -227,8 +227,8 @@ if ( ! function_exists( 'propertyhive_template_loop_property_thumbnail' ) ) {
      * @subpackage  Loop
      * @return void
      */
-    function propertyhive_template_loop_property_thumbnail($size = 'thumbnail', $class = '') {
-        echo propertyhive_get_property_thumbnail($size, $class);
+    function propertyhive_template_loop_property_thumbnail() {
+        echo propertyhive_get_property_thumbnail();
     }
 }
 
@@ -244,14 +244,14 @@ if ( ! function_exists( 'propertyhive_get_property_thumbnail' ) ) {
      * @param int $placeholder_height (default: 0)
      * @return string
      */
-    function propertyhive_get_property_thumbnail( $size = 'thumbnail', $class = '', $placeholder_width = 0, $placeholder_height = 0  ) {
+    function propertyhive_get_property_thumbnail( $size = 'medium', $class = '', $placeholder_width = 0, $placeholder_height = 0  ) {
         global $post, $property;
-        
+
         $photo_url = $property->get_main_photo_src( $size);
-        
+
         if ($photo_url !== FALSE)
             return '<img src="' . $photo_url . '" alt="' . get_the_title($post->ID) . '" class="' . $class . '">';
-        
+
         if ( ph_placeholder_img_src() )
             return ph_placeholder_img( $size );
     }
@@ -453,11 +453,11 @@ if ( ! function_exists( 'propertyhive_template_single_actions' ) ) {
      * @return void
      */
     function propertyhive_template_single_actions() {
-        
+
         global $post, $property;
-        
+
         $actions = array();
-        
+
         $floorplan_ids = $property->get_floorplan_attachment_ids();
         if ( !empty( $floorplan_ids ) )
         {
@@ -475,7 +475,7 @@ if ( ! function_exists( 'propertyhive_template_single_actions' ) ) {
                 )
             );
         }
-        
+
         $brochure_ids = $property->get_brochure_attachment_ids();
         if ( !empty( $brochure_ids ) )
         {
@@ -491,7 +491,7 @@ if ( ! function_exists( 'propertyhive_template_single_actions' ) ) {
                 );
             }
         }
-        
+
         $epc_ids = $property->get_epc_attachment_ids();
         if ( !empty( $epc_ids ) )
         {
@@ -523,21 +523,21 @@ if ( ! function_exists( 'propertyhive_template_single_actions' ) ) {
                 );
             }
         }
-        
+
         /*$actions[] = array(
             'href' => '',
             'label' => __( 'View on Map', 'propertyhive' ),
             'class' => 'action-map'
         );
-        
+
         $actions[] = array(
             'href' => '',
             'label' => __( 'Street View', 'propertyhive' ),
             'class' => 'action-street-view'
         );*/
-        
+
         $actions = apply_filters( 'propertyhive_single_property_actions', array( 'actions' => $actions ) );
-    
+
         ph_get_template( 'single-property/actions.php', $actions );
     }
 }
@@ -557,7 +557,7 @@ if ( ! function_exists( 'propertyhive_template_single_features' ) ) {
 }
 
 if ( ! function_exists( 'propertyhive_template_single_summary' ) ) {
-    
+
     /**
      * Output the product summary description.
      *
@@ -571,7 +571,7 @@ if ( ! function_exists( 'propertyhive_template_single_summary' ) ) {
 }
 
 if ( ! function_exists( 'propertyhive_template_single_rooms' ) ) {
-    
+
     /**
      * Output the product rooms to form a full description
      *
@@ -585,7 +585,7 @@ if ( ! function_exists( 'propertyhive_template_single_rooms' ) ) {
 }
 
 if ( ! function_exists( 'propertyhive_make_enquiry_button' ) ) {
-    
+
     /**
      * Output the make enquiry button and lightbox
      *


### PR DESCRIPTION
Hi Steve,

The `propertyhive_get_property_thumbnail()` isn't accepting arguments as the hook (`propertyhive_template_loop_property_thumbnail()`) has arguments added to the function which it shouldn't.

The problem now is that it was using the original image, but now it is using the `thumbnail` as it should, however WordPress' `thumbnail` is 150x150px which would most probably be too small (and cropped) for a property listings image. WooCommerce gets around this by creating a new image size called `shop_catalog` which is a lot larger. So for now I have change the default image to use `medium`, but as a future fix it might be an idea to introduce `property_large`, `property_medium`, `property_small`.

Thanks,
Tom