### PR TITLE
Possible workaround for overuse of property search hooks issue

### DIFF
--- a/includes/ph-core-functions.php
+++ b/includes/ph-core-functions.php
@@ -209,3 +209,18 @@ function get_commercial_price_units( )
     
     return $price_options;
 }
+
+/**
+ * Execute functions hooked on a specific action hook, if it exists,
+ * otherwise execute a default hook instead.
+ *
+ * @param string $tag        The name of the action to be executed (if it exists).
+ * @param string $defaultTag The name of the default action to be executed instead.
+ */
+function ph_do_action_default( $tag, $defaultTag ) {
+	if ( has_action( $tag ) ) {
+		do_action( $tag );
+	} else {
+		do_action( $defaultTag );
+	}
+}

--- a/includes/ph-template-hooks.php
+++ b/includes/ph-template-hooks.php
@@ -69,30 +69,6 @@ add_action( 'propertyhive_after_search_results_loop_item_title', 'propertyhive_t
 add_action( 'propertyhive_after_search_results_loop_item_title', 'propertyhive_template_loop_actions', 30 );
 
 /**
- * Featured Property Loop Items
- *
- * @see propertyhive_template_loop_property_thumbnail()
- * @see propertyhive_template_loop_price()
- * @see propertyhive_template_loop_actions()
- */
-add_action( 'propertyhive_before_featured_loop_item_title', 'propertyhive_template_loop_property_thumbnail', 10 );
-
-add_action( 'propertyhive_after_featured_loop_item_title', 'propertyhive_template_loop_price', 10 );
-add_action( 'propertyhive_after_featured_loop_item_title', 'propertyhive_template_loop_actions', 30 );
-
-/**
- * Recent Property Loop Items
- *
- * @see propertyhive_template_loop_property_thumbnail()
- * @see propertyhive_template_loop_price()
- * @see propertyhive_template_loop_actions()
- */
-add_action( 'propertyhive_before_recent_loop_item_title', 'propertyhive_template_loop_property_thumbnail', 10, 2 );
-
-add_action( 'propertyhive_after_recent_loop_item_title', 'propertyhive_template_loop_price', 10 );
-add_action( 'propertyhive_after_recent_loop_item_title', 'propertyhive_template_loop_actions', 20 );
-
-/**
  * Before Single Property Summary Div
  *
  * @see propertyhive_show_product_images()

--- a/templates/content-property-featured.php
+++ b/templates/content-property-featured.php
@@ -39,7 +39,7 @@ if ( $property->featured == 'yes' )
 ?>
 <li <?php post_class( $classes ); ?>>
 
-	<?php do_action( 'propertyhive_before_search_results_loop_item' ); ?>
+	<?php ph_do_action_default( 'propertyhive_before_featured_loop_item', 'propertyhive_before_search_results_loop_item' ); ?>
 
     <div class="thumbnail">
     	<a href="<?php the_permalink(); ?>">
@@ -49,7 +49,7 @@ if ( $property->featured == 'yes' )
     			 *
     			 * @hooked propertyhive_template_loop_property_thumbnail - 10
     			 */
-    			do_action( 'propertyhive_before_search_results_loop_item_title' );
+		        ph_do_action_default( 'propertyhive_before_featured_loop_item_title', 'propertyhive_before_search_results_loop_item_title' );
     		?>
         </a>
     </div>
@@ -66,11 +66,11 @@ if ( $property->featured == 'yes' )
              * @hooked propertyhive_template_loop_summary - 20
              * @hooked propertyhive_template_loop_actions - 30
     		 */
-    		do_action( 'propertyhive_after_search_results_loop_item_title' );
+	        ph_do_action_default( 'propertyhive_after_featured_loop_item_title', 'propertyhive_after_search_results_loop_item_title' );
     	?>
 	
     </div>
     
-	<?php do_action( 'propertyhive_after_search_results_loop_item' ); ?>
+	<?php ph_do_action_default( 'propertyhive_after_featured_loop_item', 'propertyhive_after_search_results_loop_item' ); ?>
 
 </li>

--- a/templates/content-property-recent.php
+++ b/templates/content-property-recent.php
@@ -39,7 +39,7 @@ if ( $property->featured == 'yes' )
 ?>
 <li <?php post_class( $classes ); ?>>
 
-	<?php do_action( 'propertyhive_before_search_results_loop_item' ); ?>
+	<?php ph_do_action_default( 'propertyhive_before_recent_loop_item', 'propertyhive_before_search_results_loop_item' ); ?>
 
     <div class="thumbnail">
     	<a href="<?php the_permalink(); ?>">
@@ -49,7 +49,7 @@ if ( $property->featured == 'yes' )
     			 *
     			 * @hooked propertyhive_template_loop_property_thumbnail - 10
     			 */
-    			do_action( 'propertyhive_before_search_results_loop_item_title' );
+		        ph_do_action_default( 'propertyhive_before_recent_loop_item_title', 'propertyhive_before_search_results_loop_item_title' );
     		?>
         </a>
     </div>
@@ -66,11 +66,11 @@ if ( $property->featured == 'yes' )
              * @hooked propertyhive_template_loop_summary - 20
              * @hooked propertyhive_template_loop_actions - 30
     		 */
-    		do_action( 'propertyhive_after_search_results_loop_item_title' );
+	        ph_do_action_default( 'propertyhive_after_recent_loop_item_title', 'propertyhive_after_search_results_loop_item_title' );
     	?>
 	
     </div>
     
-	<?php do_action( 'propertyhive_after_search_results_loop_item' ); ?>
+	<?php ph_do_action_default( 'propertyhive_after_recent_loop_item', 'propertyhive_after_search_results_loop_item' ); ?>
 
 </li>


### PR DESCRIPTION
Remove the never do_action() called featured and recent property loop item title actions and optional call them if they exist, otherwise continue to call the search results hooks.