### PR TITLE
Fix String Translation in search-form.php

### DIFF
--- a/templates/global/search-form.php
+++ b/templates/global/search-form.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
     <?php do_action( 'propertyhive_after_search_form_controls', $id, $form_controls ); ?>
 
-    <input type="submit" value="<?php echo esc_attr( 'Search', 'propertyhive' ); ?>">
+    <input type="submit" value="<?php echo esc_attr__( 'Search', 'propertyhive' ); ?>">
 
     <?php do_action( 'propertyhive_after_search_form_submit', $id, $form_controls ); ?>
 


### PR DESCRIPTION
Fix String Translation in search-form.php

Fixed (partially): https://wordpress.org/support/topic/some-strings-use-the-esc_attr-function-and-are-not-translated-4/