### PR TITLE
Declare the rest_api property at the start of the class to clear deprecation warning

### DIFF
--- a/propertyhive.php
+++ b/propertyhive.php
@@ -49,6 +49,13 @@ if ( ! class_exists( 'PropertyHive' ) )
         public $query = null;
 
         /**
+         * REST API instance.
+         *
+         * @var PH_Rest_Api
+         */
+        public $rest_api = null;
+
+        /**
          * Email instance.
          *
          * @var PH_Emails


### PR DESCRIPTION
This is a fix to clear the deprecation warning shown when using Property Hive on a fresh install using PHP 8.3.
 
Steps to reproduce:

1. Create a fresh install of WordPress
2. Enable WP_DEBUG and WP_DEBUG_LOG if preferred
3. Install Property Hive
4. A deprecation warning should be shown in the log.


This fix declares the rest_api property at the start of the class, similar to how $query is declared.

Original warning:
PHP Deprecated:  Creation of dynamic property PropertyHive::$rest_api is deprecated in /var/www/wp-content/plugins/propertyhive/propertyhive.php on line 315