### PR TITLE
class-ph-rest-api.php - fix office latitude and longitude field array

### DIFF
--- a/includes/class-ph-rest-api.php
+++ b/includes/class-ph-rest-api.php
@@ -917,8 +917,8 @@ class PH_Rest_Api {
 			'office_address_3',
 			'office_address_4',
 			'office_address_postcode',
-			'latitude',
-			'longitude',
+			'office_latitude',
+			'office_longitude',
 		);
 
 		$departments = ph_get_departments();


### PR DESCRIPTION
Existing field array definition inside register_rest_api_office_fields():
		$field_array = array(
			'primary',
			'office_address_1',
			'office_address_2',
			'office_address_3',
			'office_address_4',
			'office_address_postcode',
			'latitude',
			'longitude',
		);
incorrectly refers to latitude and longitude so that the subsequent  get_post_meta fails to retrieve the correct data. The lat/long fields on the endpoint are subsequently left empty. This fix corrects the array to reference office_latitude and office_longitude, which will then point to the correct location of the office type post meta.