### PR TITLE
Declare post_title and post_status at start of PH_Enquiry class

### DIFF
--- a/includes/class-ph-enquiry.php
+++ b/includes/class-ph-enquiry.php
@@ -17,6 +17,8 @@ class PH_Enquiry {
 
     /** @public int Enquiry (post) ID */
     public $id;
+    public $post_title;
+    public $post_status;
 
     /**
      * Get the enquiry if ID is passed, otherwise the enquiry is new and empty.


### PR DESCRIPTION
Clear deprecation warnings in PHP 8.3 when creating an enquiry or viewing enquiries in WP Admin.

This is a fix to clear some deprecation warnings shown when using Property Hive Enquiries on a fresh install using PHP 8.3.

Steps to reproduce:
1. Create a fresh install of WordPress
2. Enable WP_DEBUG and WP_DEBUG_LOG
3. Install Property Hive & add an enquiry in the admin area.
4. A deprecation warning should be shown in the log/on the page, and also in the list of enquiry entries.

Original warnings:
Deprecated: Creation of dynamic property PH_Enquiry::$post_title is deprecated in /var/www/wp-content/plugins/propertyhive/includes/class-ph-enquiry.php on line 93

Deprecated: Creation of dynamic property PH_Enquiry::$post_status is deprecated in /var/www/wp-content/plugins/propertyhive/includes/class-ph-enquiry.php on line 94