### PR TITLE
fix: enforce pro licence key for paid add-on usage

### DIFF
--- a/includes/class-ph-licenses.php
+++ b/includes/class-ph-licenses.php
@@ -87,40 +87,62 @@ class PH_Licenses {
 
         $license_type = $this->get_license_type();
 
-        if ( $license_type == 'pro' )
+        // Legacy ('old') licence holders can keep using add-ons without pro licence checks
+        if ( $license_type == 'old' )
         {
-            if ( get_option('propertyhive_pro_license_key', '') != '' ) 
-            { 
-                if ( !$this->is_valid_pro_license_key() )
-                {
-                    // show warning
-                    return false;
-                }
-
-                // Valid license. Check this plugin is valid for the purchased type of plan (i.e. map search can't be used with an 'import only' plan)
-                $feature = get_ph_pro_feature( $slug );
-                $product_id_and_package = PH()->license->get_pro_license_product_id_and_package();
-
-                if ( isset($product_id_and_package['success']) && $product_id_and_package['success'] === true )
-                {
-                    if ( 
-                        isset($feature['plans']) && 
-                        isset($product_id_and_package['package']) &&
-                        in_array($product_id_and_package['package'], $feature['plans'])
-                    )
-                    {
-                        
-                    }
-                    else
-                    {
-                    	// show warning
-                    	return false;
-                    }
-                }
-            }
+            return $can;
         }
 
-        return $can;
+        $pro_license_configured = ( $license_type == 'pro' && get_option( 'propertyhive_pro_license_key', '' ) != '' );
+
+        $feature = get_ph_pro_feature( $slug );
+
+        if ( false === $feature )
+        {
+            // A configured Pro licence must not bypass plan enforcement when
+            // the feature catalogue is unavailable, malformed, or incomplete.
+            return $pro_license_configured ? false : $can;
+        }
+
+        $plans = ( isset( $feature['plans'] ) && is_array( $feature['plans'] ) ) ? $feature['plans'] : array();
+
+        if ( in_array( 'free', $plans, true ) )
+        {
+            return $can;
+        }
+
+        // A paid add-on cannot be used without a valid Pro licence key
+        if ( ! $pro_license_configured )
+        {
+            return false;
+        }
+
+        if ( !$this->is_valid_pro_license_key() )
+        {
+            // show warning
+            return false;
+        }
+
+        // Valid license. Check this plugin is valid for the purchased type of plan (i.e. map search can't be used with an 'import only' plan)
+        $product_id_and_package = PH()->license->get_pro_license_product_id_and_package();
+
+        if ( isset($product_id_and_package['success']) && $product_id_and_package['success'] === true )
+        {
+            if (
+                isset($product_id_and_package['package']) &&
+                in_array($product_id_and_package['package'], $plans, true)
+            )
+            {
+                return $can;
+            }
+
+            // show warning
+            return false;
+        }
+
+        // The licence package could not be verified. Fail closed so a temporary
+        // upstream failure cannot unlock a paid add-on.
+        return false;
 	}
 
 	public function ph_check_add_on_can_be_updated( $can, $slug )


### PR DESCRIPTION
## Summary

Fixes an enforcement gap where paid Property Hive add-ons could be used without a licence key, and where licence/package verification failures failed open.

`PH_Licenses::ph_check_add_on_can_be_used()` only enforced anything when a pro licence key was present; otherwise it fell through to `return $can` (`true`), so manually installing the add-on files was enough to unlock paid functionality. Package verification failures also failed open.

## Changes

In `includes/class-ph-licenses.php`:

- Legacy (`'old'`) licence holders keep unrestricted access.
- Free add-ons (feature catalogue plans include `'free'`) are still allowed, now checked before the licence-key gate.
- Paid add-ons fail closed without a valid pro licence key / matching package.
- Licence/package verification failures fail closed so a temporary upstream failure cannot unlock a paid add-on.

## Testing

Verified with a scenario harness that stubs only the WordPress/network inputs and runs the real method. On the unpatched master code two scenarios fail (no-key paid add-on returns `true`; package verification failure returns `true`); after the fix all scenarios pass:

- No key + paid add-on -> blocked
- No key + free add-on -> allowed
- Legacy old licence -> allowed
- Valid key + matching plan -> allowed
- Valid key + wrong plan -> blocked
- Invalid key -> blocked
- Package verification failure -> fail closed
- Pro key + missing catalogue entry -> fail closed

`php -l includes/class-ph-licenses.php` passes.